### PR TITLE
Default timeout

### DIFF
--- a/src/Closure/RemoteCompiler.php
+++ b/src/Closure/RemoteCompiler.php
@@ -58,7 +58,11 @@ class RemoteCompiler extends AbstractCompiler
     public function getRequestHandler()
     {
         if (!isset($this->requestHandler)) {
-            $this->setRequestHandler(new \Zend\Http\Client());
+            $requestHandler = new \Zend\Http\Client();
+            $requestHandler->setOptions(array(
+                'timeout'=> 60
+            ));
+            $this->setRequestHandler($requestHandler);
         }
 
         return $this->requestHandler;


### PR DESCRIPTION
Raise default timeout from 10 to 60, as compilation of many files can take quite some time.
