### PR TITLE
Use getBody() not getContent()

### DIFF
--- a/src/Closure/RemoteCompiler.php
+++ b/src/Closure/RemoteCompiler.php
@@ -176,7 +176,7 @@ class RemoteCompiler extends AbstractCompiler
         $requestHandler->setRawBody($encodedData);
 
         $response = $requestHandler->send();
-        $xml = new \SimpleXMLElement($response->getContent());
+        $xml = new \SimpleXMLElement($response->getBody());
         $data = $this->parseXml($xml);
 
         return $this->buildResponse($data);

--- a/tests/Closure/RemoteCompilerTest.php
+++ b/tests/Closure/RemoteCompilerTest.php
@@ -46,10 +46,10 @@ class RemoteCompilerTest extends \PHPUnit_Framework_TestCase
           </statistics>
         </compilationResult>';
 
-        $httpResponse = $this->getMock('\Zend\Http\Response', array('getContent'));
+        $httpResponse = $this->getMock('\Zend\Http\Response', array('getBody'));
 
         $httpResponse->expects($this->once())
-            ->method('getContent')
+            ->method('getBody')
             ->will($this->returnValue($xml));
 
         $requestHandler = $this->getMock('\Zend\Http\Client', array('send'));


### PR DESCRIPTION
Compile is broken due to closure implementing HTTP compression.
